### PR TITLE
Fix issue with nulls being erroneously output in serialized arrays

### DIFF
--- a/gson-flatten/src/main/java/org/itishka/gsonflatten/FlattenTypeAdapterFactory.java
+++ b/gson-flatten/src/main/java/org/itishka/gsonflatten/FlattenTypeAdapterFactory.java
@@ -58,7 +58,7 @@ public class FlattenTypeAdapterFactory implements TypeAdapterFactory {
                     }
 
                     // Object didn't exist in the output already. Create it.
-                    if (object == null) {
+                    if (object == null || object.equals(JsonNull.INSTANCE)) {
                         // The next element in the chain is an array
                         if (path[i + 1].matches("^\\d+$")) {
                             object = new JsonArray();


### PR DESCRIPTION
I ran into this issue when using the flatten library like so:

```
public class A {
    @Flatten(x::0::y)
    B b;
     
    @Flatten(x::1::z)
    C c;

    @Flatten(x::2::y)
    D d;
}
```

Sometimes, the serialization code would handle `c` or `d` before `b`. When doing so, it pads the resulting `x` array with `JsonNull.INSTANCE`. When then handling `b`, it fails to pick up on the fact that this is an empty spot in the array(because `object` isn't `null`) in that case. So it "descends" into the `null` and attempts to fill it out, which fails and you end up with a `null` where a legitimate object was supposed to go

Anyway, this is a lot of explanation for what amounts to a tiny fix in the array support of this library

Cheers